### PR TITLE
達成報告の編集・削除機能の実装

### DIFF
--- a/app/controllers/achievements_controller.rb
+++ b/app/controllers/achievements_controller.rb
@@ -1,6 +1,7 @@
 class AchievementsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :move_to_index, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_achievement, only: [:edit, :update, :destroy]
 
   def new
     @training = Training.find(params[:training_id])
@@ -17,6 +18,20 @@ class AchievementsController < ApplicationController
     end
   end
 
+  def update
+    if @achievement.update(achievement_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @achievement.destroy
+      redirect_to root_path
+    end
+  end
+
   private
 
   def achievement_params
@@ -29,4 +44,10 @@ class AchievementsController < ApplicationController
       redirect_to root_path
     end
   end
+
+  def set_achievement
+    @training = Training.find(params[:training_id])
+    @achievement = Achievement.find(params[:id])
+  end
+
 end

--- a/app/views/achievements/edit.html.erb
+++ b/app/views/achievements/edit.html.erb
@@ -1,0 +1,37 @@
+<div class="achievement-format">
+  <h2 class="goal-title">完了報告の修正を行いますか？</h2>
+  <%= form_with model: @achievement, url: training_achievement_path, local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
+    <div class="form">
+      <%# 入力フォーム %>
+      <div class="new-goals">
+        <div class="end-time">
+          終了日を選択してください
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.date_field :date_end, class:"training-start", id:"training-start", placeholder:"開始日選択"%>
+        <div class="report-title">
+          達成をみんなに知らせる！※任意
+        </div>
+        <%= f.text_area :report, class:"trainig-goal", id:"training-goal", placeholder:"達成報告" %>
+        <div class="img-upload">
+          <div class="goal-title">
+            画像  ※任意
+          </div>
+          <div class="click-upload">
+            <p>
+              クリックしてファイルをアップロード
+            </p>
+            <%= f.file_field :image, id:"training-reward"%>
+          </div>
+        </div>
+        <%# ここまで入力フォーム %>
+        <%# 送信ボタン %>
+      <div class="new-goal-btn">
+        <%= f.submit "報告する" ,class:"report-btn" %>
+        <%=link_to 'TOP', root_path, class:"back-btn" %>
+      </div>
+      <%# 送信ボタン %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -23,11 +23,16 @@
                   <% if training.achievement.image.present?%>
                     <th class="table_col1">達成のごほうび</th>
                     <td class="table_col2"><%= image_tag training.achievement.image.variant(resize: '150x150') %></td>
-                    <% if training.achievement.report.present? %>
+                  <% end %>
+                  <% if training.achievement.report.present? %>
                       <th class="table_col1">目標</th>
                       <td class="table_col2"><%= training.achievement.report %></td>
-                    <% end %>
                   <% end %>
+                    <th class="table_col1">各種機能</th>
+                    <td class="table_col2">
+                      <%= link_to '修正', edit_training_achievement_path(training.id, training.achievement.id) %>
+                      <%= link_to '削除', training_achievement_path(training.id, training.achievement.id), method: :delete %>
+                    </td>
                 </table>
               <% end %>
             <% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "trainings#index"
 
   resources :trainings, only: [:index, :new, :create, :edit, :update, :destroy] do
-    resources :achievements, only: [:new, :create]
+    resources :achievements, only: [:new, :create, :edit, :update, :destroy]
   end
 
   resources :users, only: :show


### PR DESCRIPTION
# What
筋トレ目標の完了報告を編集・削除するため、以下を実装

* 編集・削除を行える
* ログアウトしているユーザーが編集機能のURLを直接入力した場合、ログイン画面へ遷移する
* 他のユーザーが自分の投稿外の完了報告編集のURLへ直接入力した場合、TOP画面へ遷移する

# Why
完了報告の変種・削除機能の実装のため

# 補足
* 機能の実装を優先しているため、CSSは最低限のみです。後ほど、修正予定です。